### PR TITLE
Fix for migration issue with steel displays.

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -54,6 +54,7 @@ for display,displaydata in pairs(DID.displays) do
 			icon_size = DID.icon_size,
 			icon_mipmaps = DID.icon_mipmaps,
 			corpse = "small-remnants",
+      fast_replaceable_group = "display",
 			minable = {
 				mining_time = 0.2,
 				result = display,

--- a/migrations/steel-display.lua
+++ b/migrations/steel-display.lua
@@ -1,0 +1,11 @@
+for index, force in pairs(game.forces) do
+  local technologies = force.technologies
+  local recipes = force.recipes
+
+  if technologies["steel-processing"].researched then
+    recipes["steel-display-small"].enabled = true
+    recipes["steel-display-medium"].enabled = true
+    recipes["steel-display"].enabled = true
+  end
+
+end


### PR DESCRIPTION
Also added fast replaceable group. Replacing a display with another resets the label unfortunately and I don't know how to fix that.